### PR TITLE
Feat/anime api integration

### DIFF
--- a/src/ssdlc_demo/main.py
+++ b/src/ssdlc_demo/main.py
@@ -1,8 +1,8 @@
+import requests
 from fastapi import FastAPI, HTTPException, Response, status
 from pydantic import BaseModel
 
 from .logging_config import configure_logging
-import requests
 
 
 class EchoRequest(BaseModel):
@@ -58,22 +58,37 @@ def get_random_anime_quote() -> AnimechanResponse:
     Endpoint used: https://api.animechan.io/v1/quotes/random
     """
     try:
-        res = requests.get("https://api.animechan.io/v1/quotes/random", timeout=5)
+        res = requests.get(
+            "https://api.animechan.io/v1/quotes/random",
+            timeout=5,
+        )
     except requests.RequestException as exc:  # network, DNS, timeout
-        raise HTTPException(status_code=502, detail="Upstream Animechan unavailable") from exc
+        raise HTTPException(
+            status_code=502,
+            detail="Upstream Animechan unavailable",
+        ) from exc
 
     if res.status_code != 200:
-        raise HTTPException(status_code=502, detail="Animechan returned non-200 status")
+        raise HTTPException(
+            status_code=502,
+            detail="Animechan returned non-200 status",
+        )
 
     try:
         payload = res.json()
     except ValueError as exc:
-        raise HTTPException(status_code=502, detail="Invalid JSON from Animechan") from exc
+        raise HTTPException(
+            status_code=502,
+            detail="Invalid JSON from Animechan",
+        ) from exc
 
     # Validate and coerce to our response model
     try:
         validated = AnimechanResponse.model_validate(payload)
     except Exception as exc:
-        raise HTTPException(status_code=502, detail="Unexpected Animechan schema") from exc
+        raise HTTPException(
+            status_code=502,
+            detail="Unexpected Animechan schema",
+        ) from exc
 
     return validated

--- a/src/ssdlc_demo/main.py
+++ b/src/ssdlc_demo/main.py
@@ -1,7 +1,8 @@
-from fastapi import FastAPI, Response, status
+from fastapi import FastAPI, HTTPException, Response, status
 from pydantic import BaseModel
 
 from .logging_config import configure_logging
+import requests
 
 
 class EchoRequest(BaseModel):
@@ -16,6 +17,28 @@ configure_logging()
 app = FastAPI(title="SSDLCDemo", version="0.1.0")
 
 
+class AnimeInfo(BaseModel):
+    id: int
+    name: str
+    altName: str | None = None
+
+
+class CharacterInfo(BaseModel):
+    id: int
+    name: str
+
+
+class AnimechanData(BaseModel):
+    content: str
+    anime: AnimeInfo
+    character: CharacterInfo
+
+
+class AnimechanResponse(BaseModel):
+    status: str
+    data: AnimechanData
+
+
 @app.get("/health")
 def health() -> dict[str, str]:
     return {"status": "ok"}
@@ -25,3 +48,32 @@ def health() -> dict[str, str]:
 def echo(payload: EchoRequest, response: Response) -> EchoResponse:
     # Any validation is handled by Pydantic models
     return EchoResponse(message=payload.message)
+
+
+@app.get("/anime/quote", response_model=AnimechanResponse)
+def get_random_anime_quote() -> AnimechanResponse:
+    """Fetch a random anime quote from Animechan and return it.
+
+    Docs: https://animechan.io/
+    Endpoint used: https://api.animechan.io/v1/quotes/random
+    """
+    try:
+        res = requests.get("https://api.animechan.io/v1/quotes/random", timeout=5)
+    except requests.RequestException as exc:  # network, DNS, timeout
+        raise HTTPException(status_code=502, detail="Upstream Animechan unavailable") from exc
+
+    if res.status_code != 200:
+        raise HTTPException(status_code=502, detail="Animechan returned non-200 status")
+
+    try:
+        payload = res.json()
+    except ValueError as exc:
+        raise HTTPException(status_code=502, detail="Invalid JSON from Animechan") from exc
+
+    # Validate and coerce to our response model
+    try:
+        validated = AnimechanResponse.model_validate(payload)
+    except Exception as exc:
+        raise HTTPException(status_code=502, detail="Unexpected Animechan schema") from exc
+
+    return validated

--- a/tests/test_anime.py
+++ b/tests/test_anime.py
@@ -1,0 +1,71 @@
+from fastapi.testclient import TestClient
+from ssdlc_demo.main import app
+
+
+def test_anime_quote_success(monkeypatch) -> None:
+    class DummyResponse:
+        status_code = 200
+
+        def json(self):
+            return {
+                "status": "success",
+                "data": {
+                    "content": "Test quote",
+                    "anime": {"id": 1, "name": "Naruto", "altName": "NARUTO"},
+                    "character": {"id": 2, "name": "Naruto Uzumaki"},
+                },
+            }
+
+    def fake_get(url, timeout=5):  # type: ignore[no-untyped-def]
+        assert url == "https://api.animechan.io/v1/quotes/random"
+        assert timeout == 5
+        return DummyResponse()
+
+    import ssdlc_demo.main as main_mod
+
+    monkeypatch.setattr(main_mod.requests, "get", fake_get)
+
+    client = TestClient(app)
+    res = client.get("/anime/quote")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["status"] == "success"
+    assert body["data"]["content"] == "Test quote"
+
+
+def test_anime_quote_upstream_error(monkeypatch) -> None:
+    class DummyResponse:
+        status_code = 500
+        def json(self):
+            return {}
+
+    def fake_get(url, timeout=5):  # type: ignore[no-untyped-def]
+        return DummyResponse()
+
+    import ssdlc_demo.main as main_mod
+
+    monkeypatch.setattr(main_mod.requests, "get", fake_get)
+
+    client = TestClient(app)
+    res = client.get("/anime/quote")
+    assert res.status_code == 502
+
+
+def test_anime_quote_invalid_json(monkeypatch) -> None:
+    class DummyResponse:
+        status_code = 200
+        def json(self):  # type: ignore[no-untyped-def]
+            raise ValueError("invalid json")
+
+    def fake_get(url, timeout=5):  # type: ignore[no-untyped-def]
+        return DummyResponse()
+
+    import ssdlc_demo.main as main_mod
+
+    monkeypatch.setattr(main_mod.requests, "get", fake_get)
+
+    client = TestClient(app)
+    res = client.get("/anime/quote")
+    assert res.status_code == 502
+
+

--- a/tests/test_anime.py
+++ b/tests/test_anime.py
@@ -1,4 +1,5 @@
 from fastapi.testclient import TestClient
+
 from ssdlc_demo.main import app
 
 
@@ -36,6 +37,7 @@ def test_anime_quote_success(monkeypatch) -> None:
 def test_anime_quote_upstream_error(monkeypatch) -> None:
     class DummyResponse:
         status_code = 500
+
         def json(self):
             return {}
 
@@ -54,6 +56,7 @@ def test_anime_quote_upstream_error(monkeypatch) -> None:
 def test_anime_quote_invalid_json(monkeypatch) -> None:
     class DummyResponse:
         status_code = 200
+
         def json(self):  # type: ignore[no-untyped-def]
             raise ValueError("invalid json")
 
@@ -67,5 +70,3 @@ def test_anime_quote_invalid_json(monkeypatch) -> None:
     client = TestClient(app)
     res = client.get("/anime/quote")
     assert res.status_code == 502
-
-


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Add new `/anime/quote` endpoint integrating Animechan API

- Define Pydantic models for anime quote response validation

- Implement comprehensive error handling for upstream failures

- Add test coverage for success and error scenarios


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["FastAPI App"] -->|"GET /anime/quote"| B["Animechan API"]
  B -->|"Random Quote"| C["Response Models"]
  C -->|"Validation"| D["AnimechanResponse"]
  B -->|"Network/Schema Error"| E["HTTPException 502"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.py</strong><dd><code>Add Animechan API integration with error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/ssdlc_demo/main.py

<ul><li>Added <code>requests</code> import and <code>HTTPException</code> for external API calls<br> <li> Created three Pydantic models: <code>AnimeInfo</code>, <code>CharacterInfo</code>, <br><code>AnimechanData</code>, and <code>AnimechanResponse</code> for response validation<br> <li> Implemented <code>/anime/quote</code> GET endpoint with comprehensive error <br>handling for network failures, invalid status codes, JSON parsing <br>errors, and schema validation<br> <li> Endpoint calls Animechan API with 5-second timeout and validates <br>response structure</ul>


</details>


  </td>
  <td><a href="https://github.com/StatusNeo/ssdlc-demo/pull/122/files#diff-d81c77a37d8937ba69b1381703219f1bf930737d1d3649e8090f9b75bd2ba213">+68/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_anime.py</strong><dd><code>Add comprehensive tests for anime quote endpoint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_anime.py

<ul><li>Created new test file with three test cases for the anime quote <br>endpoint<br> <li> <code>test_anime_quote_success</code>: Verifies successful quote retrieval and <br>response structure<br> <li> <code>test_anime_quote_upstream_error</code>: Tests handling of non-200 upstream <br>status codes<br> <li> <code>test_anime_quote_invalid_json</code>: Tests handling of invalid JSON <br>responses from upstream<br> <li> All tests use monkeypatch to mock <code>requests.get</code> calls</ul>


</details>


  </td>
  <td><a href="https://github.com/StatusNeo/ssdlc-demo/pull/122/files#diff-36cd0b70447d08efa6aa46d4282580a1926618380cb884ce2e2e103211542e39">+72/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

